### PR TITLE
Update to 1.20

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,7 @@
 name: SQLiteLib
 main: com.pablo67340.SQLiteLib.Main.SQLiteLib
 version: 1.3
+api-version: '1.20'
 author: pablo67340
 description: Plugin for any server.
 commands:

--- a/pom.xml
+++ b/pom.xml
@@ -56,14 +56,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.12.1-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
-        </dependency>
-        <!--Bukkit API-->
-        <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>bukkit</artifactId>
-            <version>1.12.1-R0.1-SNAPSHOT</version>
+            <version>1.20.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Updated the Spigot API to 1.20, and tested it to verify it still works. Also added the API version to the "plugin.yml" file to remove the legacy plugin error.